### PR TITLE
Collapse notification shade on failed tile click.

### DIFF
--- a/app/src/main/java/com/franco/demomode/tiles/DemoModeTile.kt
+++ b/app/src/main/java/com/franco/demomode/tiles/DemoModeTile.kt
@@ -45,7 +45,7 @@ class DemoModeTile : TileService() {
                     Intent(applicationContext, MainActivity::class.java).apply {
                         action = Utils.MISSING_PERMISSION
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                        startActivity(this)
+                        startActivityAndCollapse(this)
                     }
                 }
 


### PR DESCRIPTION
https://developer.android.com/develop/ui/views/quicksettings-tiles#launch_an_activity